### PR TITLE
docs(Spec and add_model_instructions.md): Added docs and changed the guide on adding a new model

### DIFF
--- a/add_model_instructions.md
+++ b/add_model_instructions.md
@@ -1,38 +1,145 @@
-## Instruction to add a model to trained_model repository
+# How to add a model to the NoBrainer-zoo Documentation
 
-1. we suggest to create a separate environment to submit your model.
-- install and configure [git](https://github.com/git-guides/install-git), [git-annex](https://git-annex.branchable.com/install/) and also you need a github account.
-- Install and configure [datalad](https://handbook.datalad.org/en/latest/intro/installation.html)
+Status: In progress
+Assign: Edward Gaibor
+Research Backtracking: Week 3 (https://www.notion.so/Week-3-5ff64911dc9d4ee2b922d099d12e0a75?pvs=21)
 
-2. Fork and then clone the trained_model repository from your Fork. You can use either git or datalad.
+# **README - Trained Model Deployment**
 
-	Using git:```git clone git@github.com:<your_github>/trained-models.git```
+This README provides instructions for deploying a trained model using the **`nobrainer-zoo`** framework. Follow the steps below to set up your model repository and test it locally before creating a pull request.
 
-	or
+## **Environment Setup**
 
-	Using datalad:```datalad clone git@github.com:<your_github>/trained-models.git```
+1. Create a separate environment to submit your model:
+    - Install **`git`**, **`git-annex`**, and **`datalad`**. If you are using a cluster environment like OpenMind, you can add them using **`module add openmind/<module>` or installing the manually**.
 
-	
-3. **NOTE: do not create a new branch. Work on master branch.** The structure of the repository is ```<org>/<model_name>/<version>```. Create these nested directories with proper names and version of your model. Organization name can refer to your affiliation. You need below files for adding your model,
-	- **saved model file or weights:** add the model file in a subdirectory called ```weights```
-	- **sep.yaml:** this file contains an information about your model, command to run, training dataset and etc. check the template [here](https://github.com/neuronets/trained-models/blob/master/docs/spec.yaml). 
-	- **prediction.py:** script for getting inference from the model
-	- **train.py:** script for training of the model 
-	- **requirement.txt:** list of model dependencies for inference and train
-	- **Dockerfile:** docker file to build a container
+## **Repository Setup**
 
-You may submit your model only for inference, in that case you may not have the ```train.py``` file.
+1. **Fork the main `trained-models` repository and clone it locally:**
+    - You can use either **`datalad`** or **`git`** to clone the repository. It is recommended to use **`datalad`** to avoid issues later on with saving the dataset.
+    - Using git: **`git clone git@github.com:<your_github>/trained-models.git`**
+    - Using datalad: **`datalad clone git@github.com:<your_github>/trained-models.git`**
+2. **Create the folder structure for your new model repository:**
+    - Inside the forked repository, create a folder structure following this pattern: **`<org>/<model_name>/<version>`**.
+    - The organization name can refer to your affiliation.
+3. **Inside the ‘<org>/<model_name>/<version>’ folder path you just created you will need to add several files:**
+    - **Create a folder named weights.**
+        - Under this folder you will save the already trained model file checkpoint (i. e. a .pth or .h5 file)
+    - **Create a file named spec.yaml (you can refer to the template: docs/spec.yaml and documentation on docs/spec_file.md):**
+    - This is the file that specifies the command for your script to run either predict, train, generate, etc.
+    - Various examples of spec.yaml files can be found under each models ‘<org>/<model_name>/<version>’ folder.
+        1. [https://github.com/gaiborjosue/trained-models/blob/master/neuronets/ams/0.1.0/spec.yaml](https://github.com/gaiborjosue/trained-models/blob/master/neuronets/ams/0.1.0/spec.yaml)
+        2. [https://github.com/gaiborjosue/trained-models/blob/master/UCL/SynthSR/1.0.0/general/spec.yaml](https://github.com/gaiborjosue/trained-models/blob/master/UCL/SynthSR/1.0.0/general/spec.yaml)
+    - **Upload your predict.py file that you use to process the model and give an output.**
+    - **If you are using any other feature such as train or generate, add those files as well.**
+    - **Depending on your Dockerfile you can add either a requirements.txt or a requirements.yaml file including all the necessary dependencies and libraries your container needs so that the prediction can run smoothly.**
+    - **Add your Dockerfile.**
+4. **Now you need to upload the trained model file saved under the ‘weights’ folder to a publicly available space. For example, you can use google drive and allow everyone to access reading permissions on that file. For more details on how to do that please visit:** [https://workspacetips.io/tips/drive/share-a-google-drive-file-publicly/](https://workspacetips.io/tips/drive/share-a-google-drive-file-publicly/)
+    1. After you saved the model in a publicly available space you can run the following command:
+    
+    ```powershell
+    git annex addurl --relaxed --file <path_to_model_file> <google_drive_url>
+    ```
+    
+5. **After running git annex on your model file, git annex should automatically create a branch on your forked repo with the details of the model storage.**
+6. **Now we should save the dataset with a commit message from the root of the trained_models repository. You can do that by running the following code:**
+    
+    ```powershell
+    datalad save -m “Added model X”
+    ```
+    
+7. **After you saved the dataset, we can push the changes to github with datalad:**
+    
+    ```powershell
+    datalad push --to origin
+    ```
+    
 
-4. You need to upload the trained_model file in a cloud space that is publically available. for example google drive with permission to everyone to read. You will store it in `gitannex` by the following command. 
+## Testing your model locally before creating a Pull Request
 
-	```git annex addurl --relaxed --file <path_to_model_file> <google_drive_url```
+1. **If you want to test your model before creating a pull request please go to the nobrainer-zoo repo: https://github.com/neuronets/nobrainer-zoo and clone it inside an isolated environment (recommended).**
+2. **Before testing anything, please ensure you installed nobrainer-zoo. For testing purposes instead of installing nobrainer-zoo normally with pip, we are going to install it in editable mode.**
+    1. To do so, please activate your new environment, go to the cloned repo of nobrainer-zoo and in the parent folder run the following:
+        
+        ```powershell
+        pip install -e .
+        ```
+        
+        After installation, Nobrainer-zoo should be initialized. It also needs a cache folder to download some helper files based on your needs. By default, it creates a cache folder in your home directory (`~/.nobrainer`). If you do not want the cache folder in your `home` directory, you can setup a different cache location by setting the environmental variable `NOBRAINER_CACHE`. run below command to set it.
+        
+        ```powershell
+        export NOBRAINER_CACHE=<path_to_your_cache_directory>
+        ```
+        
+3. **After you cloned it locally and installed nobrainer-zoo go to the ‘nobrainerzoo’ folder and select cli.py**
+4. **In this python file please search for the ‘model_db_url’ variable and replace its value (the current url of trained-models repo) with your forked repo. I. E.**
+    
+    ```
+    Before:
+    # adding trained_model repository
+        model_db_url = "https://github.com/neuronets/trained-models"
+    
+    After:
+    # adding trained_model repository
+        model_db_url = "https://github.com/gaiborjosue/trained-models"
+    ```
+    
+5. **After you have done this change you can test out your model by running the cli.py script.**
+    1. To ensure that you can actually run your model, please run this command:
+        
+        ```powershell
+        python cli.py ls
+        ```
+        
+        A list of all the available models will be printed, please ensure that your model is in the list with the format ‘<org>/<model_name>/<version>’.
+        
+    2. After you’ve ensured that your model is capable of being used, please run the following command to test it out.
+        
+        ```powershell
+        python cli.py predict -m <MODEL/model/version> <path-to-your-input> <path-to-your-output> --container_type <container-docker-or-singularity>
+        ```
+        
+    
+6. **If you do not see your model under “cli.py ls” list, a quick solution is manually adding the parent folder of your new model to nobrainer’s cache.** 
+    - For this please copy the parent directory of your new model (<org>/<model_name>/<version> it would be the org).
+    - Then go to your terminal and do the following:
+        
+        ```powershell
+        cd ~/.nobrainer
+        ```
+        
+        If you changed the nobrainer cache folder, please cd into that directory.
+        
+    - After going to nobrainer’s cache directory please go into the folder named “trained_models”
+    - Inside that folder paste your new model’s parent directory folder containing your model’s required files to run.
+    - Now when you repeat the cli.py ls command your model should show up under the list.
+    - Now repeat the step mentioned in 6.b
 
-5. Save the dataset with a commit message from the root of the repository.
-	
-	```datalad save -m “Added model X”```
-			
-6. Push the changes to the github.
-	
-	```datalad push --to origin```
-	
-7. Send the pull request to the [neuronet/trained_model](git@github.com:neuronets/trained-models.git) repository.
+### Test your model using Nobrainer-zoo
+
+1. **The first step to test your model using nobrainer-zoo after your model ran normally with cli.py is to initialize the nobrainer-zoo by running:**
+    
+    ```powershell
+    nobrainer-zoo init
+    ```
+    
+
+1. **After initializing your nobrainer-zoo, please run this command to see if your model is on the list of available models:**
+    
+    ```powershell
+    nobrainer-zoo ls
+    ```
+    
+2. **If you see your model in that list, it means it is capable of running. Now you can test your model with the example command in your spec.yaml file. In example:**
+    
+    
+    ```powershell
+    nobrainer-zoo predict -m <MODEL>/<model>/<version> <PATH_TO_INPUT> <PATH_TO_OUTPUT> --container_type <DOCKER_or_SINGULARITY>
+    ```
+    
+
+1. **If it worked both with cli.py and nobrainer-zoo it means your model should be ready for merging.**
+
+## **Creating a Pull Request**
+
+After testing your model locally, you can create a pull request with your forked repository to merge your changes into the main **`trained-models`** repository.

--- a/add_model_instructions.md
+++ b/add_model_instructions.md
@@ -1,9 +1,3 @@
-# How to add a model to the NoBrainer-zoo Documentation
-
-Status: In progress
-Assign: Edward Gaibor
-Research Backtracking: Week 3 (https://www.notion.so/Week-3-5ff64911dc9d4ee2b922d099d12e0a75?pvs=21)
-
 # **README - Trained Model Deployment**
 
 This README provides instructions for deploying a trained model using the **`nobrainer-zoo`** framework. Follow the steps below to set up your model repository and test it locally before creating a pull request.

--- a/docs/spec.yaml
+++ b/docs/spec.yaml
@@ -1,0 +1,100 @@
+train:
+  #### Train Script
+  train_script: [Path to the training script goes here]
+
+  #### General Settings
+  name: [Model name goes here]
+  is_train: [Specify if it's training mode (true/false) goes here]
+  #use_visdom: [Specify if Visdom is used for visualization (true/false) goes here]
+  #visdom_port: [Port number for Visdom visualization goes here]
+
+  #### Datasets
+  n_classes: [Number of classes goes here]
+  dataset_train:
+    data_location: [Location of training data goes here]
+    shuffle_buffer_size: [Shuffle buffer size goes here]
+    block_shape: [Block shape goes here]
+    volume_shape: [Volume shape goes here]
+    batch_size: [Batch size for training goes here]
+    augment: [Specify if data augmentation is used (true/false) goes here]
+    n_train: [Number of training samples goes here]
+    num_parallel_calls: [Number of parallel calls goes here]
+
+  dataset_test:
+    data_location: [Location of test data goes here]
+    shuffle_buffer_size: [Shuffle buffer size goes here]
+    block_shape: [Block shape goes here]
+    volume_shape: [Volume shape goes here]
+    batch_size: [Batch size for testing goes here]
+    n_test: [Number of test samples goes here]
+    num_parallel_calls: [Number of parallel calls goes here]
+    augment: [Specify if data augmentation is used (true/false) goes here]
+
+  #### Network Structures
+  network:
+    model: [Model architecture goes here]
+    batchnorm: [Specify if batch normalization is used (true/false) goes here]
+
+  #### Training Settings: Learning rate scheme, loss
+  training:
+    epoch: [Number of epochs goes here]
+    lr: [Learning rate goes here]
+    loss: [Loss function goes here]
+    metrics: [List of evaluation metrics goes here]
+
+  #### Logger
+  logger:
+    ckpt_path: [Checkpoint path goes here]
+
+#### Training Data Characteristics
+training_data_info:
+  data_number:
+    total: [Total number of data goes here]
+    train: [Number of training data goes here]
+    evaluate: [Number of evaluation data goes here]
+    test: [Number of test data goes here]
+  biological_sex:
+    male: [Number of male data goes here]
+    female: [Number of female data goes here]
+  age_histogram: [Age histogram goes here]
+  race: [Race information goes here]
+  imaging_contrast_info: [Imaging contrast information goes here]
+  dataset_sources: [Dataset sources go here]
+  data_sites:
+    number_of_sites: [Number of data sites goes here]
+    sites: [List of data site names goes here]
+  scanner_models: [Scanner models go here]
+  hardware: [Hardware information goes here]
+  training_parameters:
+    input_shape: [Input shape used for training goes here]
+    block_shape: [Block shape used for training goes here]
+    n_classes: [Number of classes used for training goes here]
+    lr: [Learning rate used for training goes here]
+    n_epochs: [Number of epochs used for training goes here]
+    total_batch_size: [Total batch size used for training goes here]
+    number_of_gpus: [Number of GPUs used for training goes here]
+    loss_function: [Loss function used for training goes here]
+    metrics: [List of evaluation metrics used for training goes here]
+    data_preprocessing: [Description or details about the data preprocessing steps goes here]
+    data_augmentation: [Description or details about the data augmentation techniques used goes here]
+
+#### Model Information and Help
+model:
+  model_name: [Model name goes here]
+  description: [Brief description of the model goes here]
+  structure: [Model structure goes here]
+  training_mode: [Training mode of the model goes here]
+  model_url: [URL of the model's repository goes here]
+  Zoo_function: [Zoo function or command to use the model goes here]
+  example: [Example usage of the model goes here]
+  note: [Any additional notes or instructions about the model go here]
+  input_file_type: [Type of input file expected by the model goes here]
+  model_details: [Detailed information about the model goes here]
+  intended_use: [Intended use or application of the model goes here]
+  factors: [Factors or considerations that may affect the model's performance or results go here]
+  metrics: [Evaluation metrics used for the model go here]
+  eval_data: [Details about the data used for model evaluation go here]
+  training_data: [Details about the data used for model training go here]
+  quant_analyses: [Quantitative analyses or experiments conducted with the model go here]
+  ethical_considerations: [Ethical considerations related to the model's usage or impact go here]
+  caveats_recs: [Any caveats, recommendations, or limitations of the model go here]

--- a/docs/spec_file.md
+++ b/docs/spec_file.md
@@ -1,0 +1,118 @@
+# The spec.yaml Guide
+
+For a template please refer to docs/spec.yaml
+
+The following things should be included in your spec.yaml file
+
+1. The singularity and docker image paths:
+    1. **For Docker:**
+        1. Please create an image with your specified dockerfile. You can do so by running the following command:
+            
+            ```powershell
+            docker build -t <image_name> <path_to_dockerfile_directory>
+            ```
+            
+        2. Now that you have created an image you can publish it to a repository:
+            
+            To push a Docker image to a repository, you need to follow these steps:
+            
+            1. Log in to the repository: Use the **`docker login`** command to log in to the container registry where you want to push the image. Replace **`<repository>`** with the URL of the registry. You will be prompted to provide your username and password or access token.
+                
+                ```
+                docker login <repository>
+                ```
+                
+            2. Tag the image: Before pushing, you need to tag the local image with the repository URL and desired tag. Use the **`docker tag`** command with the following syntax:
+                
+                ```
+                docker tag <image_name> <repository>/<image_name>:<tag>
+                ```
+                
+                Replace **`<image_name>`** with the name of your local image and **`<repository>`** with the URL of the container registry. You can specify a tag for the image, or it will default to **`latest`**.
+                
+                For example:
+                
+                ```
+                docker tag myimage <repository>/myimage:latest
+                ```
+                
+            3. Push the image: Once the image is tagged, you can push it to the repository using the **`docker push`** command:
+                
+                ```
+                
+                docker push <repository>/<image_name>:<tag>
+                ```
+                
+                Replace **`<repository>`**, **`<image_name>`**, and **`<tag>`** with the appropriate values. The image will be uploaded to the specified repository.
+                
+                For example:
+                
+                ```
+                docker push <repository>/myimage:latest
+                ```
+                
+        3. Now that you have published that image you can add it to the spec.yaml under the image/docker key:
+            
+            ```powershell
+            docker: docker://neuronets/nobrainer-zoo:deepcsr
+            ```
+            
+    2. **For singularity:**
+        1. For singularity you may create an image with your docker image. You can do so by running the following:
+            1. Make sure you have Singularity installed and configured on your system.
+            2. Open a terminal or command prompt.
+            3. Use the following command to create a Singularity image from a Docker image:
+                
+                ```
+                shellCopy code
+                singularity build <output_image_file> docker://<docker_image>
+                
+                ```
+                
+                Replace **`<output_image_file>`** with the desired name and path of the Singularity image file you want to create. Replace **`<docker_image>`** with the name of the Docker image you want to convert.
+                
+                For example:
+                
+                ```
+                shellCopy code
+                singularity build myimage.sif docker://myrepo/myimage:latest
+                
+                ```
+                
+                This command will create a Singularity image file named **`myimage.sif`** from the Docker image **`myrepo/myimage:latest`**. Ensure that you have appropriate permissions and access to the Docker image.
+                
+            4. Wait for the Singularity image creation process to complete. This may take some time depending on the size and complexity of the Docker image.
+        2. Now that you have created a singularity file, specifiy its path in the spec.yaml file under image/singularity:
+            
+            ```powershell
+            image:
+              singularity: <Path_to_the_image>
+              docker: neuronets/nobrainer-zoo:deepcsr
+            ```
+            
+2. Repo information (If none, then just include “None” in every repository variable).
+3. For inference or prediction please specify the path to the [predict](http://predict.py).py file your model uses to work and actually output a prediction.
+4. Under the same category of inference, create a command. For example:
+    
+    ```powershell
+    command: f"python {MODELS_PATH}/{model}/predict.py --conf_path {infile[0]}"
+    ```
+    
+    What this command is doing is calling python, then it will autofill with the path to the [predict.py](http://predict.py) file uploaded to the '<org>/<model_name>/<version>’ directory, after this it will pass any options or arguments you have detailed inside your predict.py to accept as a standard input. In the example above it inputs a config file path that will later be used, so therefore, the flag —conf_path is used. After the flag the actual ‘infile’ or user input should be passed with {} since its an f string.
+    
+    As an example, your inference key in spec.yaml should look something like this:
+    
+    ```powershell
+    inference:
+        prediction_script: "trained-models/DeepCSR/deepcsr/1.0/predict.py"
+        command: f"python {MODELS_PATH}/{model}/predict.py --conf_path {infile[0]} {outfile}"
+    
+        #### input data characteristics
+        data_spec:
+          infile: {n_files: 1}
+    			outfile: {n_files: 1}
+    ```
+    
+5. If you are using the template, you can remove the training keys if you are not allowing training functionalities on your model.
+6. After that, complete the model information and help.
+7. If you need guidance please refer to the examples provided of previous models.


### PR DESCRIPTION
This will create a new folder named docs, which contains two files: spec.yaml and spec_file.md. These include a template for the spec.yaml file and a guide on adding/modifying its information.

Also, I modified the add_model_instructions.md adding the explanation on how to test the model locally before creating a pull request to the principal repository.