### PR TITLE
fix(get_model_data): Parse model_card instead of spec

### DIFF
--- a/.github/workflows/get_model_data.yml
+++ b/.github/workflows/get_model_data.yml
@@ -37,8 +37,8 @@ jobs:
 
       - name: Extract files from clone and remove clone
         run: |
-          mv ./trained-models-template/docs .
-          rm -r ./trained-models-template
+          mv ./trained-models-template/docs/* ./docs
+          rm -r ./trained-models-template/
       
       - name: Use GitHub Actions' cache to shorten build times and decrease load on servers
         uses: actions/cache@v2


### PR DESCRIPTION
Hello,

This pull request updates the workflow "get_model_data", where now it parses the "model_card.yaml" instead of "spec.yaml".

A live version of this update can be found on my fork's page: https://gaiborjosue.github.io/trained-models-fork/

In the URL above, the only model card showing up is DeepCSR, this is because DeepCSR is the only model with a "model_card.yaml". **Thus, we first need to add model_card.yaml to every model before merging this pull request, so the website displays the correct values.**

The major updates go towards the javascript file, but I also updated the extraction of the clone directory in the workflow.

This Pull request will close #106 